### PR TITLE
Fix for: Origin security crash when upgrading to 1.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function RPC (src, dst, origin, methods) {
     var self = this;
     this.src = src;
     this.dst = dst;
-    this._dstIsWorker = /Worker/.test(dst);
+    this._dstIsWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope;
     
     if (origin === '*') {
         this.origin = '*';


### PR DESCRIPTION
I experienced the same issue:  Origin security crash when upgrading to 1.4

I changed the web worker test with the high ranking answer here:
https://stackoverflow.com/questions/7931182/reliably-detect-if-the-script-is-executing-in-a-web-worker
